### PR TITLE
Add PostgreSQL Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,14 +17,16 @@ repositories {
 
 dependencies {
     compileOnly "org.spongepowered:spongecommon:${minecraft_version}-${sponge_version}:dev"
-
     compileOnly "com.azanor.baubles:Baubles:${baubles_version}"
+
     deobfProvided "cyclic:Cyclic:${cyclic_version}"
     deobfProvided "codersafterdark.reskillable:Reskillable:${minecraft_version}-${reskillable_version}"
     deobfProvided "spice-of-life-carrot-edition:solcarrot:${solcarrot_version}"
     deobfProvided "the-spice-of-life:SpiceOfLife:${spiceOfLive_version}"
     deobfProvided "thaumcraft:Thaumcraft:${minecraft_version}:${thaumcraft_version}"
     deobfProvided "com.github.glitchfiend.biomesoplenty:ToughAsNails:${minecraft_version}-${toughAsNails_version}:api"
+
+    shadow "org.postgresql:postgresql:42.2.18"
 
     testRuntime "org.spongepowered:spongecommon:${minecraft_version}-${sponge_version}:dev"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ repositories {
 
 dependencies {
     compileOnly "org.spongepowered:spongecommon:${minecraft_version}-${sponge_version}:dev"
-    compileOnly "com.azanor.baubles:Baubles:${baubles_version}"
 
+    compileOnly "com.azanor.baubles:Baubles:${baubles_version}"
     deobfProvided "cyclic:Cyclic:${cyclic_version}"
     deobfProvided "codersafterdark.reskillable:Reskillable:${minecraft_version}-${reskillable_version}"
     deobfProvided "spice-of-life-carrot-edition:solcarrot:${solcarrot_version}"
@@ -26,7 +26,7 @@ dependencies {
     deobfProvided "thaumcraft:Thaumcraft:${minecraft_version}:${thaumcraft_version}"
     deobfProvided "com.github.glitchfiend.biomesoplenty:ToughAsNails:${minecraft_version}-${toughAsNails_version}:api"
 
-    shadow "org.postgresql:postgresql:42.2.18"
+    shadow "org.postgresql:postgresql:${postgres_version}"
 
     testRuntime "org.spongepowered:spongecommon:${minecraft_version}-${sponge_version}:dev"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
-# All commented out settings show their default value and can be left out, if they will not be changed.
-# Values in parententeses (only for default values) will be filled with the evaluated value.
-# Plugin Name is preferably set in the settings.gradle file.
+// All commented out settings show their default value and can be left out, if they will not be changed.
+// Values in parententeses (only for default values) will be filled with the evaluated value.
+// Plugin Name is preferably set in the settings.gradle file.
 
-# If Forge:
+// If Forge:
 org.gradle.jvmargs=-Xmx2G
 
 type=spongeforge
@@ -14,9 +14,10 @@ description=This plugin synchronizes the player inventory with a database
 customCharts=true
 enableMockTesting=true
 
-# Versions
+// Versions
 spotBugs_version=3.1.8
-bStats_version=1.6
+bStats_version=1.7
+postgres_version=42.2.18
 
 sponge_version=7.2.0
 minecraft_version=1.12.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
-// All commented out settings show their default value and can be left out, if they will not be changed.
-// Values in parententeses (only for default values) will be filled with the evaluated value.
-// Plugin Name is preferably set in the settings.gradle file.
+# All commented out settings show their default value and can be left out, if they will not be changed.
+# Values in parententeses (only for default values) will be filled with the evaluated value.
+# Plugin Name is preferably set in the settings.gradle file.
 
-// If Forge:
+# If Forge:
 org.gradle.jvmargs=-Xmx2G
 
 type=spongeforge
@@ -14,9 +14,9 @@ description=This plugin synchronizes the player inventory with a database
 customCharts=true
 enableMockTesting=true
 
-// Versions
+# Versions
 spotBugs_version=3.1.8
-bStats_version=1.7
+bStats_version=1.6
 
 sponge_version=7.2.0
 minecraft_version=1.12.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri Oct 16 11:53:24 EEST 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Oct 16 11:53:24 EEST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/src/main/java/world/jnc/invsync/util/database/DataSource.java
+++ b/src/main/java/world/jnc/invsync/util/database/DataSource.java
@@ -103,9 +103,7 @@ public class DataSource {
         .append(tableInventories)
         .append(" WHERE ")
         .append(tableInventoriesColumnUUID)
-        .append(" = ?");
-
-    if (!storageConfig.isPostgreSQL()) getInventoryStr.append(" LIMIT 1");
+        .append(" = ? LIMIT 1");
 
     setActiveStr
         .append("UPDATE ")
@@ -125,9 +123,7 @@ public class DataSource {
         .append(tableInventories)
         .append(" WHERE ")
         .append(tableInventoriesColumnUUID)
-        .append(" = ?");
-
-    if (!storageConfig.isPostgreSQL()) isActiveStr.append(" LIMIT 1");
+        .append(" = ? LIMIT 1");
 
     insertInventoryQuery = insertInventoryStr.toString();
     loadInventoryQuery = getInventoryStr.toString();

--- a/src/main/java/world/jnc/invsync/util/database/PostgreSQLDatabaseConnection.java
+++ b/src/main/java/world/jnc/invsync/util/database/PostgreSQLDatabaseConnection.java
@@ -1,0 +1,41 @@
+package world.jnc.invsync.util.database;
+
+import java.sql.SQLException;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import world.jnc.invsync.config.Config;
+
+public class PostgreSQLDatabaseConnection extends DatabaseConnection {
+  private static final String URLFormat =
+      "jdbc:postgresql://%1$s:%2$d/%3$s?user=%4$s&password=%5$s%6$s";
+  private static final String URLFormatNoPassword =
+      "jdbc:postgresql://%1$s:%2$d/%3$s?user=%4$s%6$s";
+
+  private static String formatProperties(Map<String, String> properties) {
+    if (properties == null || properties.isEmpty()) {
+      return StringUtils.EMPTY;
+    }
+
+    StringBuilder props = new StringBuilder();
+    properties.forEach((k, v) -> props.append("&").append(k).append("=").append(v));
+    return props.toString();
+  }
+
+  /**
+   * Opens a PostgreSQL database connection.
+   *
+   * @param postgresql PostgreSQL config object
+   * @throws SQLException
+   */
+  protected PostgreSQLDatabaseConnection(Config.Storage.PostgreSQL postgresql) throws SQLException {
+    super(
+        String.format(
+            postgresql.getPassword().isEmpty() ? URLFormatNoPassword : URLFormat,
+            postgresql.getHost(),
+            postgresql.getPort(),
+            postgresql.getDatabase(),
+            postgresql.getUserEncoded(),
+            postgresql.getPasswordEncoded(),
+            formatProperties(postgresql.getProperties())));
+  }
+}

--- a/src/main/java/world/jnc/invsync/util/metrics/FeatureChart.java
+++ b/src/main/java/world/jnc/invsync/util/metrics/FeatureChart.java
@@ -16,6 +16,7 @@ public class FeatureChart extends SimpleBarChart {
     final Config.Storage storageConfig = config.getStorage();
 
     sortedMap.put("MySQL", storageConfig.isMySQL() ? 1 : 0);
+    sortedMap.put("PostgreSQL", storageConfig.isPostgreSQL() ? 1 : 0);
     sortedMap.put("H2", storageConfig.isH2() ? 1 : 0);
 
     for (BaseSyncModule module : PlayerSerializer.getModules()) {


### PR DESCRIPTION
This should address #14 
Some notes:

* bStats 1.7's `Metrics2` class constructor is not annotated with `@Inject`, so I had to downgrade it to 1.6 in order to test.
* The comments in `gradle.properties` were written with backslashes, which is actually incorrect for `.properties` files. This PR also addresses this.

The abstraction layer over the database connection stuff ( SqlService and the like ) was not intended for use with different sql syntaxes and implementations ( PostgreSQL's syntax is different than MySQL in many ways ), I've had to do all of this in a way which I personally don't consider optimal. If this plugin intends to support multiple databases, it should really have at least something like jOOQ or an ORM of some sort. 

This pull request also shadows the postgresql driver into the final built jar. There's no other place from which it could come, so it would have to be included one way or another. This increases the size of the final plugin jar substantially ( By ~1MB )

⚠️ I have not done any regression testing in terms of the already-existing h2 or mysql stuff. I have only tested the new PostgreSQL functionality.

⚠️ I have also not tested this with any of the mods that are supported. Just vanilla SpongeForge.